### PR TITLE
Check if pr_count/issue_count has items

### DIFF
--- a/octohat/helpers.py
+++ b/octohat/helpers.py
@@ -54,10 +54,17 @@ def get_data(uri):
 
 def get_pri_count(repo_name):
     prs = get_data("/repos/%s/pulls?state=all" % repo_name)
-    pr_count = prs[0]["number"]
-
     issues = get_data("/repos/%s/issues?state=all" % repo_name)
-    issue_count = issues[0]["number"]
+
+    if not prs:
+        pr_count = 0
+    else:
+        pr_count = prs[0]["number"]
+
+    if not issues:
+        issue_count = 0
+    else:
+        issue_count = issues[0]["number"]
 
     return max(pr_count, issue_count)
 


### PR DESCRIPTION
list index out of range occurs when running on a repo with no issues/prs

      File "/usr/local/bin/octohat", line 9, in <module>
        load_entry_point('octohat==0.1.0', 'console_scripts', 'octohat')()
      File "/Library/Python/2.7/site-packages/octohat/__init__.py", line 22, in main
        code_commentors = get_code_commentors(repo_name, args.limit)
      File "/Library/Python/2.7/site-packages/octohat/helpers.py", line 31, in get_code_commentors
        pri_count = get_pri_count(repo_name)
      File "/Library/Python/2.7/site-packages/octohat/helpers.py", line 60, in get_pri_count
        pr_count = prs[0]["number"]
    IndexError: list index out of range
